### PR TITLE
fix: update publications permalink configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,4 @@
 collections:
   publications:
     output: true # true にすると各論文のHTMLページが /publications/ファイル名.html として生成される
+    permalink: /publications/:id.html


### PR DESCRIPTION
Fix 404 errors for publication pages by updating the permalink configuration in _config.yml