### PR TITLE
Repair incomplete paper detail pages and missing metadata

### DIFF
--- a/_papers/2024_mechaja.md
+++ b/_papers/2024_mechaja.md
@@ -11,8 +11,7 @@ venue: '情報処理学会 第263回自然言語処理研究会 研究報告 (20
 date: 2024-11-01
 type: domestic
 description: '視覚言語モデルにおける日本文化・日常生活知識理解を評価するための MECHA-Ja ベンチマークを提案。'
-pdf:
-code_link:
+pdf: /assets/papers/2024_mechaja.pdf
 bibtex: |
   @inproceedings{maeda2024mechaja,
     title = {日本の文化常識・日常生活知識理解のための視覚言語ベンチマーク MECHA-Ja の構築},

--- a/_papers/2025_instruction_tuning.md
+++ b/_papers/2025_instruction_tuning.md
@@ -22,5 +22,11 @@ date: 2025-07-22
 type: international
 firstpage: 1
 lastpage: 15
-bibtex: '@inproceedings{}'
+bibtex: |
+  @inproceedings{ma2025instruction,
+    title={Building instruction-tuning datasets from human-written instructions with open-weight large language models},
+    author={Youmi Ma and Sakae Mizuki and Kazuki Fujii and Taishi Nakamura and Masanari Ohi and Hinari Shimada and Taihei Shiotani and Koshiro Saito and Koki Maeda and Kakeru Hattori and Takumi Okamoto and Shigeki Ishida and Rio Yokota and Hiroya Takamura and Naoaki Okazaki},
+    booktitle={The 2nd Conference on Language Modeling (COLM)},
+    year={2025}
+  }
 ---

--- a/_papers/2025_whywe.md
+++ b/_papers/2025_whywe.md
@@ -21,5 +21,11 @@ date: 2025-07-22
 type: international
 firstpage: 1
 lastpage: 15
-bibtex: '@inproceedings{}'
+bibtex: |
+  @inproceedings{saito2025whywe,
+    title={Why We Build Local Large Language Models: An Observational Analysis from 35 Japanese and Multilingual LLMs},
+    author={Koshiro Saito and Sakae Mizuki and Masanari Ohi and Taishi Nakamura and Taihei Shiotani and Koki Maeda and Youmi Ma and Kakeru Hattori and Kazuki Fujii and Takumi Okamoto and Shigeki Ishida and Hiroya Takamura and Rio Yokota and Naoaki Okazaki},
+    booktitle={The 1st Workshop on Multilingual and Equitable Language Technologies (MELT)},
+    year={2025}
+  }
 ---

--- a/_papers/2026_hatch.md
+++ b/_papers/2026_hatch.md
@@ -9,6 +9,9 @@ authors:
   - Naoaki Okazaki
 venue: arXiv preprint
 date: 2026-02-09
+description: Proposes a framework for evaluating human-like multi-image spatial reasoning
+  in multi-modal large language models, analyzing how models establish correspondence
+  across images and translate spatial understanding into actions.
 type: international
 pdf: /assets/papers/hatch-2026.pdf
 bibtex: |

--- a/scripts/validate-papers.sh
+++ b/scripts/validate-papers.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Validate paper metadata in _papers/ for completeness.
+# Exit 0 if all papers pass, exit 1 if any issues found.
+set -euo pipefail
+
+PAPERS_DIR="${1:-_papers}"
+errors=0
+
+for file in "$PAPERS_DIR"/*.md; do
+  slug=$(basename "$file" .md)
+  front=$(sed -n '/^---$/,/^---$/p' "$file")
+
+  # Required fields
+  for field in title authors venue date type; do
+    if ! echo "$front" | grep -q "^${field}:"; then
+      echo "ERROR [$slug]: missing required field '$field'"
+      errors=$((errors + 1))
+    fi
+  done
+
+  # Check for placeholder BibTeX
+  if echo "$front" | grep -qE "bibtex:\s*'@\w+\{\}'"; then
+    echo "ERROR [$slug]: placeholder BibTeX (@type{})"
+    errors=$((errors + 1))
+  fi
+
+  # Check type value
+  type_val=$(echo "$front" | grep '^type:' | sed 's/type:\s*//' | tr -d '[:space:]')
+  if [ -n "$type_val" ] && [ "$type_val" != "international" ] && [ "$type_val" != "domestic" ]; then
+    echo "ERROR [$slug]: invalid type '$type_val' (expected international or domestic)"
+    errors=$((errors + 1))
+  fi
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "Found $errors issue(s) in paper metadata."
+  exit 1
+else
+  echo "All papers pass validation."
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- Replaced placeholder BibTeX (`@inproceedings{}`) in 2025_instruction_tuning and 2025_whywe with proper entries
- Added description to 2026_hatch
- Added PDF path for 2024_mechaja (was empty)
- Created `scripts/validate-papers.sh` for repeatable metadata validation

## Test plan
- [x] Jekyll build succeeds
- [x] No placeholder BibTeX in built output
- [x] Validation script passes for all papers
- [x] Prettier formatting check passes

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)