### PR TITLE
Normalize summary density on the full publications page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -365,6 +365,10 @@ a:focus {
 
 .paper-card .paper-description {
   margin: 0.5rem 0 0.75rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .paper-links {


### PR DESCRIPTION
## Summary
- Added CSS `-webkit-line-clamp: 2` to `.paper-card .paper-description` to limit description display to 2 lines
- Full descriptions remain available on individual paper detail pages
- No data changes needed — purely presentational fix

## Test plan
- [x] Jekyll build succeeds
- [x] Prettier formatting check passes
- [x] Paper cards show truncated descriptions consistently

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)