### PR TITLE
Add a stronger top section to /papers

### DIFF
--- a/_layouts/papers.html
+++ b/_layouts/papers.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 {% assign international = site.papers | where: 'type', 'international' | sort: 'date' | reverse %} {% assign domestic =
-site.papers | where: 'type', 'domestic' | sort: 'date' | reverse %}
+site.papers | where: 'type', 'domestic' | sort: 'date' | reverse %} {% assign recent = international | slice: 0, 3 %}
 
 <section class="page-section papers-index">
   <div class="container">
@@ -13,6 +13,12 @@ site.papers | where: 'type', 'domestic' | sort: 'date' | reverse %}
       <p class="section-description">{{ page.intro }}</p>
       {% endif %}
     </header>
+
+    <div class="paper-group paper-group--featured">
+      <h2>Recent Work</h2>
+      <div class="paper-list">{% for paper in recent %} {% include paper-card.html paper=paper %} {% endfor %}</div>
+    </div>
+
     <div class="paper-groups">
       <div class="paper-group">
         <h2>International Publications &amp; Preprints</h2>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -528,6 +528,12 @@ a:focus {
   margin-bottom: 1rem;
 }
 
+.paper-group--featured {
+  margin-bottom: 2.5rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
 .post-list {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- Added a "Recent Work" section at the top of /papers showing the 3 most recent international papers
- Added visual separator between featured and archive sections
- Full archive remains below as the authoritative list

## Test plan
- [x] Jekyll build succeeds
- [x] Prettier formatting check passes
- [x] Recent Work section shows 3 most recent papers
- [x] Full archive still accessible below

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)