### PR TITLE
Add filtering and grouping controls to /papers

### DIFF
--- a/_includes/paper-card.html
+++ b/_includes/paper-card.html
@@ -1,4 +1,4 @@
-<article class="paper-card">
+<article class="paper-card" data-year="{{ paper.date | date: '%Y' }}" data-type="{{ paper.type }}">
   <h3 class="paper-title">
     <a href="{{ paper.url | relative_url }}">{{ paper.title }}</a>
   </h3>

--- a/_layouts/papers.html
+++ b/_layouts/papers.html
@@ -2,8 +2,10 @@
 layout: default
 ---
 
-{% assign international = site.papers | where: 'type', 'international' | sort: 'date' | reverse %} {% assign domestic =
-site.papers | where: 'type', 'domestic' | sort: 'date' | reverse %} {% assign recent = international | slice: 0, 3 %}
+{% assign all_papers = site.papers | sort: 'date' | reverse %} {% assign international = site.papers | where: 'type',
+'international' | sort: 'date' | reverse %} {% assign domestic = site.papers | where: 'type', 'domestic' | sort: 'date'
+| reverse %} {% assign recent = international | slice: 0, 3 %} {% assign years = all_papers | map: 'date' | map: 'year'
+| uniq %}
 
 <section class="page-section papers-index">
   <div class="container">
@@ -19,17 +21,81 @@ site.papers | where: 'type', 'domestic' | sort: 'date' | reverse %} {% assign re
       <div class="paper-list">{% for paper in recent %} {% include paper-card.html paper=paper %} {% endfor %}</div>
     </div>
 
-    <div class="paper-groups">
-      <div class="paper-group">
+    <nav class="paper-filters" aria-label="Filter publications">
+      <div class="filter-group">
+        <span class="filter-label">Type</span>
+        <button class="filter-btn active" data-filter-type="all">All</button>
+        <button class="filter-btn" data-filter-type="international">International</button>
+        <button class="filter-btn" data-filter-type="domestic">Domestic</button>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">Year</span>
+        <select class="filter-select" data-filter-year>
+          <option value="all">All years</option>
+          {% for year in years %}
+          <option value="{{ year }}">{{ year }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </nav>
+
+    <div class="paper-groups" id="paper-archive">
+      <div class="paper-group" data-group-type="international">
         <h2>International Publications &amp; Preprints</h2>
         <div class="paper-list">
           {% for paper in international %} {% include paper-card.html paper=paper %} {% endfor %}
         </div>
       </div>
-      <div class="paper-group">
+      <div class="paper-group" data-group-type="domestic">
         <h2>Domestic Conferences</h2>
         <div class="paper-list">{% for paper in domestic %} {% include paper-card.html paper=paper %} {% endfor %}</div>
       </div>
     </div>
   </div>
 </section>
+
+<script>
+  (function () {
+    var typeFilter = 'all';
+    var yearFilter = 'all';
+    var typeBtns = document.querySelectorAll('[data-filter-type]');
+    var yearSelect = document.querySelector('[data-filter-year]');
+    var groups = document.querySelectorAll('#paper-archive .paper-group');
+
+    function apply() {
+      groups.forEach(function (group) {
+        var groupType = group.getAttribute('data-group-type');
+        var cards = group.querySelectorAll('.paper-card');
+        var visible = 0;
+        cards.forEach(function (card) {
+          var matchType = typeFilter === 'all' || card.getAttribute('data-type') === typeFilter;
+          var matchYear = yearFilter === 'all' || card.getAttribute('data-year') === yearFilter;
+          var show = matchType && matchYear;
+          card.style.display = show ? '' : 'none';
+          if (show) visible++;
+        });
+        if (typeFilter !== 'all' && groupType !== typeFilter) {
+          group.style.display = 'none';
+        } else {
+          group.style.display = visible > 0 ? '' : 'none';
+        }
+      });
+    }
+
+    typeBtns.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        typeBtns.forEach(function (b) {
+          b.classList.remove('active');
+        });
+        btn.classList.add('active');
+        typeFilter = btn.getAttribute('data-filter-type');
+        apply();
+      });
+    });
+
+    yearSelect.addEventListener('change', function () {
+      yearFilter = this.value;
+      apply();
+    });
+  })();
+</script>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -534,6 +534,68 @@ a:focus {
   border-bottom: 1px solid var(--border);
 }
 
+.paper-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: center;
+  margin-bottom: 2rem;
+  padding: 1rem 1.2rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.filter-btn {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.filter-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.filter-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.filter-select {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.88rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
 .post-list {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- Added type filter buttons (All / International / Domestic) to /papers
- Added year dropdown filter
- Paper cards now carry `data-year` and `data-type` attributes
- Lightweight client-side JS filtering with no external dependencies
- No-JS fallback: full unfiltered list remains visible

## Test plan
- [x] Jekyll build succeeds
- [x] Filter controls render in built output
- [x] All 24+ paper cards have data attributes
- [x] Prettier formatting check passes

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)