### PR TITLE
Define supporting content strategy for thin subpages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,5 +4,5 @@
   url: /cv/
 - title: Papers
   url: /papers/
-- title: Blog
+- title: Notes
   url: /blog/

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -5,7 +5,7 @@ layout: default
 <section class="page-section blog-index">
   <div class="container">
     <header class="section-header">
-      <h1>Blog</h1>
+      <h1>{{ page.title }}</h1>
       {% if page.intro %}
       <p class="section-description">{{ page.intro }}</p>
       {% endif %}

--- a/pages/blog.md
+++ b/pages/blog.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-title: Blog
+title: Research Notes
 permalink: /blog/
-intro: 'Long-form notes on multimodal research, evaluation, and community updates.'
+intro: 'Practical tips, tool reviews, and lessons learned from multimodal and NLP research. For formal publications, see <a href="/papers/">Papers</a>.'
 ---


### PR DESCRIPTION
## Summary
- Rebranded /blog as "Research Notes" in navigation and page title
- Updated intro to clearly define its role (practical tips/tools) with cross-link to /papers
- Blog layout now uses dynamic `page.title` instead of hardcoded "Blog"

## Content Strategy
- **/papers**: Formal publication archive (authoritative record)
- **/cv**: Professional profile and academic CV
- **/blog (Notes)**: Practical research tips, tool reviews, and lessons learned

## Test plan
- [x] Jekyll build succeeds
- [x] Navigation shows "Notes" instead of "Blog"
- [x] Page title shows "Research Notes"
- [x] Cross-link to /papers renders correctly
- [x] Prettier formatting check passes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)