### PR TITLE
Integrity cleanup: broken link, dead CSS, DRY violation

### DIFF
--- a/_includes/cv-pub-item.html
+++ b/_includes/cv-pub-item.html
@@ -1,0 +1,12 @@
+{%- assign entry = include.cvpubs | where: 'id', include.paper.slug | first -%} {%- if entry -%} {%- assign authors =
+include.paper.authors -%} {%- assign venue = include.paper.venue | default: include.paper.journal -%} {%- capture
+author_line -%}{%- include author-highlight.html authors=authors last_sep="." -%}{%- endcapture -%} {%- include
+cv-pub-meta.html entry=entry venue=venue -%}
+<li class="cv-pub-item">
+  <span class="cv-pub-authors">{{ author_line | strip }}</span>
+  <span class="cv-pub-title"> <em>{{ include.paper.title }}</em></span>
+  {%- if meta_line %}
+  <span class="cv-pub-meta"> · {{ meta_line | strip }}</span>
+  {%- endif %}
+</li>
+{%- endif -%}

--- a/_papers/2023_quic360.md
+++ b/_papers/2023_quic360.md
@@ -23,8 +23,6 @@ bibtex: "@inproceedings{maeda2023quic360,\n  title = {Query-based Image Captioni
   \ Linguistics}\n}"
 ---
 
-[PDF](/assets/papers/2023_quic360.pdf)
-
 ## Abstract
 
 This paper introduces Query-based Image Captioning (QuIC) for 360-degree images, where a query (words or short phrases) specifies the context to describe. This task is more challenging than conventional image captioning, as it requires fine-grained scene understanding to select content consistent with the user's intent based on the query. We constructed a dataset comprising 3,940 360-degree images and 18,459 pairs of queries and captions annotated manually. Experiments demonstrate that fine-tuning image captioning models on our dataset can generate more diverse and controllable captions from multiple contexts of 360-degree images.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -721,10 +721,6 @@ a:focus {
   margin: 0;
 }
 
-.muted {
-  color: var(--text-muted);
-}
-
 .site-footer {
   background: var(--surface);
   border-top: 1px solid var(--border);

--- a/pages/cv.md
+++ b/pages/cv.md
@@ -109,40 +109,14 @@ lang: en
   <h3>International Publications &amp; Preprints</h3>
   <ol class="cv-pub-list">
     {% for paper in international %}
-      {% assign entry = cvpubs | where: 'id', paper.slug | first %}
-      {% if entry %}
-        {% assign authors = paper.authors %}
-        {% assign venue = paper.venue | default: paper.journal %}
-        {% capture author_line %}{% include author-highlight.html authors=authors last_sep="." %}{% endcapture %}
-        {% include cv-pub-meta.html entry=entry venue=venue %}
-        <li class="cv-pub-item">
-          <span class="cv-pub-authors">{{ author_line | strip }}</span>
-          <span class="cv-pub-title"> <em>{{ paper.title }}</em></span>
-          {% if meta_line %}
-            <span class="cv-pub-meta"> · {{ meta_line | strip }}</span>
-          {% endif %}
-        </li>
-      {% endif %}
+      {% include cv-pub-item.html paper=paper cvpubs=cvpubs %}
     {% endfor %}
   </ol>
 
   <h3>Domestic Conferences</h3>
   <ol class="cv-pub-list" start="{{ international | size | plus: 1 }}">
     {% for paper in domestic %}
-      {% assign entry = cvpubs | where: 'id', paper.slug | first %}
-      {% if entry %}
-        {% assign authors = paper.authors %}
-        {% assign venue = paper.venue | default: paper.journal %}
-        {% capture author_line %}{% include author-highlight.html authors=authors last_sep="." %}{% endcapture %}
-        {% include cv-pub-meta.html entry=entry venue=venue %}
-        <li class="cv-pub-item">
-          <span class="cv-pub-authors">{{ author_line | strip }}</span>
-          <span class="cv-pub-title"> <em>{{ paper.title }}</em></span>
-          {% if meta_line %}
-            <span class="cv-pub-meta"> · {{ meta_line | strip }}</span>
-          {% endif %}
-        </li>
-      {% endif %}
+      {% include cv-pub-item.html paper=paper cvpubs=cvpubs %}
     {% endfor %}
   </ol>
 </section>


### PR DESCRIPTION
## Summary
- Removed broken `[PDF]` link from 2023_quic360.md body (frontmatter `pdf:` has correct external URL)
- Removed unused `.muted` CSS class from main.css
- Extracted duplicated CV publication rendering into `_includes/cv-pub-item.html`

## Test plan
- [x] Jekyll build succeeds with 25 CV pub items
- [x] No broken quic360 PDF link in output
- [x] No .muted class in CSS
- [x] Prettier formatting check passes

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)