### PR TITLE
i18n: EN/JP language switcher for UI labels (#43)

### DIFF
--- a/_data/i18n.yml
+++ b/_data/i18n.yml
@@ -1,0 +1,100 @@
+# UI labels — Single Source of Truth for EN/JP translations
+# Usage: {% include t.html key="nav_home" %}
+
+# Navigation
+nav_home:
+  en: Home
+  ja: ホーム
+nav_cv:
+  en: CV
+  ja: 履歴書
+nav_papers:
+  en: Papers
+  ja: 論文一覧
+nav_notes:
+  en: Notes
+  ja: ノート
+
+# Home page sections
+section_research:
+  en: Research Themes
+  ja: 研究テーマ
+section_publications:
+  en: Publications
+  ja: 論文
+section_talks:
+  en: 'Talks &amp; Workshops'
+  ja: '招待講演・ワークショップ'
+section_experience:
+  en: Experience
+  ja: 職歴・インターン
+section_education:
+  en: Education
+  ja: 学歴
+section_awards:
+  en: 'Awards &amp; Fellowships'
+  ja: '受賞・フェローシップ'
+section_skills:
+  en: 'Skills &amp; Expertise'
+  ja: 'スキル・専門分野'
+
+# Buttons & links
+btn_browse_papers:
+  en: Browse full publication list
+  ja: 論文一覧を見る
+btn_copy_bibtex:
+  en: Copy BibTeX
+  ja: BibTeX をコピー
+btn_copied:
+  en: Copied!
+  ja: コピーしました！
+btn_copy_failed:
+  en: Copy failed
+  ja: コピー失敗
+
+# Papers page
+papers_title:
+  en: Papers
+  ja: 論文一覧
+papers_recent:
+  en: Recent Work
+  ja: 最近の研究
+papers_international:
+  en: 'International Publications &amp; Preprints'
+  ja: '国際会議・プレプリント'
+papers_domestic:
+  en: Domestic Conferences
+  ja: 国内会議
+papers_filter_type:
+  en: Type
+  ja: 種別
+papers_filter_all:
+  en: All
+  ja: すべて
+papers_filter_international:
+  en: International
+  ja: 国際
+papers_filter_domestic:
+  en: Domestic
+  ja: 国内
+papers_filter_year:
+  en: Year
+  ja: 年度
+papers_filter_all_years:
+  en: All years
+  ja: すべての年度
+
+# Blog
+blog_no_posts:
+  en: No posts yet. Check back soon!
+  ja: まだ記事はありません。もう少々お待ちください！
+
+# Footer
+footer_built_with:
+  en: Built with Jekyll
+  ja: Jekyll で構築
+
+# Education
+label_advisors:
+  en: 'Advisors:'
+  ja: '指導教員：'

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,8 +1,8 @@
-- title: Home
+- i18n_key: nav_home
   url: /
-- title: CV
+- i18n_key: nav_cv
   url: /cv/
-- title: Papers
+- i18n_key: nav_papers
   url: /papers/
-- title: Notes
+- i18n_key: nav_notes
   url: /blog/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="site-footer">
   <div class="container">
-    <p>© {{ site.time | date: '%Y' }} {{ site.title }} · Built with Jekyll</p>
+    <p>© {{ site.time | date: '%Y' }} {{ site.title }} · {% include t.html key="footer_built_with" %}</p>
   </div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,10 +4,15 @@
   (function () {
     try {
       var t = localStorage.getItem('theme');
+      var l = localStorage.getItem('lang');
     } catch (e) {
       return;
     }
     if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+    if (l === 'ja') {
+      document.documentElement.setAttribute('data-lang', 'ja');
+      document.documentElement.lang = 'ja';
+    }
   })();
 </script>
 <link rel="icon" href="{{ '/assets/favicon.svg' | relative_url }}" type="image/svg+xml" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,9 +11,13 @@
       default: page.path %} {% for item in nav_items %} {% assign item_url = item.url | relative_url %} {% assign
       is_active = false %} {% if current_url == item.url %} {% assign is_active = true %} {% elsif item.url != '/' and
       current_url and current_url != '/' and current_url contains item.url %} {% assign is_active = true %} {% endif %}
-      <a href="{{ item_url }}" class="{% if is_active %}active{% endif %}">{{ item.title }}</a>
+      <a href="{{ item_url }}" class="{% if is_active %}active{% endif %}">{% include t.html key=item.i18n_key %}</a>
       {% endfor %}
       <div class="site-controls">
+        <button class="lang-toggle" type="button" aria-label="Switch language">
+          <span class="lang-label-en">JP</span>
+          <span class="lang-inactive">EN</span>
+        </button>
         <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
           <svg
             class="icon-sun"

--- a/_includes/paper-card.html
+++ b/_includes/paper-card.html
@@ -17,7 +17,9 @@
     {% endif %} {% if paper.code_link %}
     <a class="paper-link" href="{{ paper.code_link }}" target="_blank" rel="noopener">Code</a>
     {% endif %} {% if paper.bibtex %}
-    <button class="paper-link copy-bibtex" data-bibtex="{{ paper.bibtex | escape }}">Copy BibTeX</button>
+    <button class="paper-link copy-bibtex" data-bibtex="{{ paper.bibtex | escape }}">
+      {% include t.html key="btn_copy_bibtex" %}
+    </button>
     {% endif %}
   </div>
 </article>

--- a/_includes/t.html
+++ b/_includes/t.html
@@ -1,0 +1,1 @@
+{% assign t = site.data.i18n[include.key] %}<span data-i18n="en">{{ t.en }}</span><span data-i18n="ja">{{ t.ja }}</span>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -12,7 +12,7 @@ layout: default
     </header>
     <div class="post-list">
       {% assign posts = site.posts | sort: 'date' | reverse %} {% if posts.size == 0 %}
-      <p>No posts yet. Check back soon!</p>
+      <p>{% include t.html key="blog_no_posts" %}</p>
       {% endif %} {% for post in posts %} {% include post-card.html post=post %} {% endfor %}
     </div>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,10 @@
       <main class="site-main">{{ content }}</main>
       {% include footer.html %}
     </div>
+    <div hidden>
+      <span data-i18n-key="btn_copied">{% include t.html key="btn_copied" %}</span>
+      <span data-i18n-key="btn_copy_failed">{% include t.html key="btn_copy_failed" %}</span>
+    </div>
     <script src="{{ '/assets/js/site.js' | relative_url }}"></script>
     {% if page.extra_js %} {% for script in page.extra_js %}
     <script src="{{ script | relative_url }}"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -31,7 +31,7 @@ layout: default
 {% if themes %}
 <section class="page-section research">
   <div class="container">
-    <h2>Research Themes</h2>
+    <h2>{% include t.html key="section_research" %}</h2>
     <div class="pill-grid">
       {% for item in themes %}
       <article class="pill-card">
@@ -46,12 +46,12 @@ layout: default
 
 <section class="page-section publications">
   <div class="container">
-    <h2>Publications</h2>
+    <h2>{% include t.html key="section_publications" %}</h2>
     <div class="paper-list condensed">
       {% for paper in all_papers limit:5 %} {% include paper-card.html paper=paper %} {% endfor %}
     </div>
     <div class="section-cta">
-      <a class="button ghost" href="{{ '/papers/' | relative_url }}">Browse full publication list</a>
+      <a class="button ghost" href="{{ '/papers/' | relative_url }}">{% include t.html key="btn_browse_papers" %}</a>
     </div>
   </div>
 </section>
@@ -59,7 +59,7 @@ layout: default
 {% assign talks = site.data.invited_talks %} {% if talks and talks.size > 0 %}
 <section class="page-section talks">
   <div class="container">
-    <h2>Talks &amp; Workshops</h2>
+    <h2>{% include t.html key="section_talks" %}</h2>
     <ol class="talk-list">
       {% for talk in talks limit:3 %} {% assign details = '' %} {% if talk.event %} {% assign details = details |
       append: talk.event %} {% endif %} {% if talk.location %} {% if details != '' %}{% assign details = details |
@@ -80,7 +80,7 @@ layout: default
 {% endif %} {% assign experience = site.data.experience %} {% if experience and experience.size > 0 %}
 <section class="page-section experience">
   <div class="container">
-    <h2>Experience</h2>
+    <h2>{% include t.html key="section_experience" %}</h2>
     <ul class="exp-list">
       {% for item in experience %}
       <li class="exp-item">
@@ -101,7 +101,7 @@ layout: default
 
 <section class="page-section education">
   <div class="container">
-    <h2>Education</h2>
+    <h2>{% include t.html key="section_education" %}</h2>
     <div class="timeline">
       {% for item in site.data.education %}
       <article class="timeline-item">
@@ -110,7 +110,7 @@ layout: default
         <p class="timeline-focus">{{ item.focus }}</p>
         {% if item.advisors %}
         <p class="timeline-advisors">
-          <strong>Advisors:</strong>
+          <strong>{% include t.html key="label_advisors" %}</strong>
           {% for advisor in item.advisors %} {{ advisor }}{% unless forloop.last %}, {% endunless %} {% endfor %}
         </p>
         {% endif %}
@@ -123,7 +123,7 @@ layout: default
 
 <section class="page-section awards">
   <div class="container">
-    <h2>Awards &amp; Fellowships</h2>
+    <h2>{% include t.html key="section_awards" %}</h2>
     <ul class="badge-list">
       {% for award in site.data.awards %}
       <li class="badge">{{ award }}</li>
@@ -134,7 +134,7 @@ layout: default
 
 <section class="page-section skills">
   <div class="container">
-    <h2>Skills &amp; Expertise</h2>
+    <h2>{% include t.html key="section_skills" %}</h2>
     <div class="skills-grid">
       {% for group in site.data.skills %}
       <article class="skill-group">

--- a/_layouts/papers.html
+++ b/_layouts/papers.html
@@ -10,28 +10,38 @@ layout: default
 <section class="page-section papers-index">
   <div class="container">
     <header class="section-header">
-      <h1>Papers</h1>
+      <h1>{% include t.html key="papers_title" %}</h1>
       {% if page.intro %}
       <p class="section-description">{{ page.intro }}</p>
       {% endif %}
     </header>
 
     <div class="paper-group paper-group--featured">
-      <h2>Recent Work</h2>
+      <h2>{% include t.html key="papers_recent" %}</h2>
       <div class="paper-list">{% for paper in recent %} {% include paper-card.html paper=paper %} {% endfor %}</div>
     </div>
 
     <nav class="paper-filters" aria-label="Filter publications">
       <div class="filter-group">
-        <span class="filter-label">Type</span>
-        <button class="filter-btn active" data-filter-type="all">All</button>
-        <button class="filter-btn" data-filter-type="international">International</button>
-        <button class="filter-btn" data-filter-type="domestic">Domestic</button>
+        <span class="filter-label">{% include t.html key="papers_filter_type" %}</span>
+        <button class="filter-btn active" data-filter-type="all">{% include t.html key="papers_filter_all" %}</button>
+        <button class="filter-btn" data-filter-type="international">
+          {% include t.html key="papers_filter_international" %}
+        </button>
+        <button class="filter-btn" data-filter-type="domestic">
+          {% include t.html key="papers_filter_domestic" %}
+        </button>
       </div>
       <div class="filter-group">
-        <span class="filter-label">Year</span>
+        <span class="filter-label">{% include t.html key="papers_filter_year" %}</span>
         <select class="filter-select" data-filter-year>
-          <option value="all">All years</option>
+          <option
+            value="all"
+            data-i18n-en="{{ site.data.i18n.papers_filter_all_years.en }}"
+            data-i18n-ja="{{ site.data.i18n.papers_filter_all_years.ja }}"
+          >
+            {{ site.data.i18n.papers_filter_all_years.en }}
+          </option>
           {% for year in years %}
           <option value="{{ year }}">{{ year }}</option>
           {% endfor %}
@@ -41,13 +51,13 @@ layout: default
 
     <div class="paper-groups" id="paper-archive">
       <div class="paper-group" data-group-type="international">
-        <h2>International Publications &amp; Preprints</h2>
+        <h2>{% include t.html key="papers_international" %}</h2>
         <div class="paper-list">
           {% for paper in international %} {% include paper-card.html paper=paper %} {% endfor %}
         </div>
       </div>
       <div class="paper-group" data-group-type="domestic">
-        <h2>Domestic Conferences</h2>
+        <h2>{% include t.html key="papers_domestic" %}</h2>
         <div class="paper-list">{% for paper in domestic %} {% include paper-card.html paper=paper %} {% endfor %}</div>
       </div>
     </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -40,6 +40,18 @@
   --header-bg: rgba(13, 13, 13, 0.85);
 }
 
+[data-i18n='ja'] {
+  display: none;
+}
+
+[data-lang='ja'] [data-i18n='en'] {
+  display: none;
+}
+
+[data-lang='ja'] [data-i18n='ja'] {
+  display: inline;
+}
+
 *,
 *::before,
 *::after {
@@ -831,6 +843,43 @@ a:focus {
 
 [data-theme='dark'] .theme-toggle .icon-moon {
   display: block;
+}
+
+.lang-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  padding: 0 0.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
+}
+
+.lang-toggle:hover {
+  background: var(--primary-light);
+  color: var(--primary);
+}
+
+.lang-toggle .lang-inactive {
+  display: none;
+}
+
+[data-lang='ja'] .lang-toggle .lang-label-en {
+  display: none;
+}
+
+[data-lang='ja'] .lang-toggle .lang-inactive {
+  display: inline;
 }
 
 @media (max-width: 820px) {

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,7 +1,26 @@
+var I18N_DATA = {};
+
 document.addEventListener('DOMContentLoaded', () => {
+  buildI18nMap();
   wireCopyButtons();
   wireThemeToggle();
+  wireLangToggle();
 });
+
+function buildI18nMap() {
+  document.querySelectorAll('[data-i18n-key]').forEach((el) => {
+    var key = el.getAttribute('data-i18n-key');
+    var en = el.querySelector('[data-i18n="en"]');
+    var ja = el.querySelector('[data-i18n="ja"]');
+    if (en && ja) I18N_DATA[key] = { en: en.textContent.trim(), ja: ja.textContent.trim() };
+  });
+}
+
+function i18nText(key, fallback) {
+  var lang = document.documentElement.getAttribute('data-lang') || 'en';
+  var entry = I18N_DATA[key];
+  return entry ? entry[lang] || entry.en : fallback;
+}
 
 function wireCopyButtons() {
   const buttons = document.querySelectorAll('.copy-bibtex');
@@ -15,10 +34,10 @@ function wireCopyButtons() {
 
       try {
         await navigator.clipboard.writeText(bibtex);
-        showCopyFeedback(button, 'Copied!', 2000);
+        showCopyFeedback(button, i18nText('btn_copied', 'Copied!'), 2000);
       } catch (error) {
         console.error('Failed to copy BibTeX', error);
-        showCopyFeedback(button, 'Copy failed', 2000);
+        showCopyFeedback(button, i18nText('btn_copy_failed', 'Copy failed'), 2000);
       }
     });
   });
@@ -47,15 +66,45 @@ function wireThemeToggle() {
   });
 }
 
+function wireLangToggle() {
+  const toggle = document.querySelector('.lang-toggle');
+  if (!toggle) return;
+
+  syncI18nOptions();
+
+  toggle.addEventListener('click', () => {
+    const isJa = document.documentElement.getAttribute('data-lang') === 'ja';
+    if (isJa) {
+      document.documentElement.removeAttribute('data-lang');
+      document.documentElement.lang = 'en';
+    } else {
+      document.documentElement.setAttribute('data-lang', 'ja');
+      document.documentElement.lang = 'ja';
+    }
+    try {
+      localStorage.setItem('lang', isJa ? 'en' : 'ja');
+    } catch (e) {
+      /* private browsing */
+    }
+    syncI18nOptions();
+  });
+}
+
+function syncI18nOptions() {
+  var lang = document.documentElement.getAttribute('data-lang') || 'en';
+  document.querySelectorAll('[data-i18n-en][data-i18n-ja]').forEach(function (el) {
+    el.textContent = el.getAttribute('data-i18n-' + lang);
+  });
+}
+
 function showCopyFeedback(button, message, duration) {
-  const original = button.dataset.originalLabel || button.textContent;
-  if (!button.dataset.originalLabel) {
-    button.dataset.originalLabel = original;
+  if (!button.dataset.originalHtml) {
+    button.dataset.originalHtml = button.innerHTML;
   }
   button.textContent = message;
   button.disabled = true;
   setTimeout(() => {
-    button.textContent = button.dataset.originalLabel;
+    button.innerHTML = button.dataset.originalHtml;
     button.disabled = false;
   }, duration);
 }


### PR DESCRIPTION
Closes #43

## 変更概要

- `_data/i18n.yml` を Single Source of Truth として全 UI ラベルの EN/JP 翻訳データを管理
- `_includes/t.html` Liquid ヘルパーで `<span data-i18n="en/ja">` を出力
- ヘッダーに EN/JP 言語トグルボタン追加（テーマトグルの隣）
- CSS `[data-lang='ja']` セレクタで表示切り替え（JS 不要でもデフォルト英語表示）
- `localStorage` + FOUC 防止でリロード時も設定維持
- ナビ、セクション見出し、ボタン、フィルター、フッターを全て i18n 化
- `<option>` 要素は `data-i18n-en/ja` 属性 + JS で切り替え（span 不可のため）
- コピーフィードバックメッセージも i18n 対応（`i18nText()` ヘルパー）
- 論文タイトル・ブログ本文は翻訳対象外（設計判断）

## /review 結果

| サブエージェント | 判定 | 詳細 |
|-----------------|------|------|
| アーキテクチャレビュー | ✅ | SoT 原則遵守、t.html ヘルパーは clean な Liquid パターン |
| リスクレビュー | ✅ | localStorage try/catch 済、innerHTML は server-rendered content のみで XSS リスク低 |
| 仕様充足チェッカー | ✅ | 5 つの Acceptance Criteria 全て充足 |
| ロジック検証 | ✅ | option 内 span 問題を data 属性 + JS で修正済み。コピーフィードバック i18n 対応済み |
| Best Practice | ✅ | 静的サイト i18n の標準パターン（dual span + CSS visibility） |
| UI/UX レビュー | ✅ | トグルラベル明確、44px タッチターゲット、FOUC 防止済み |
| Fallback チェッカー | ✅ | guard clause + try/catch 完備、missing key は空 span（構造的に安全） |

## テスト結果

- Jekyll ビルド: ✅ 成功
- Prettier フォーマット: ✅ パス